### PR TITLE
fix(gaussianpicker): Fix check that picktime is inside picking window

### DIFF
--- a/quakemigrate/signal/pick/gaussianpicker.py
+++ b/quakemigrate/signal/pick/gaussianpicker.py
@@ -272,6 +272,8 @@ class GaussianPicker(PhasePicker):
             win_min = S_idxmin
             win_max = S_idxmax
 
+        logging.debug(f"Win_min = {win_min} ; Win_max = {win_max}")
+
         # Find index of maximum value of onset function in the appropriate
         # pick window
         max_onset = np.argmax(onset[win_min:win_max]) + win_min
@@ -323,6 +325,8 @@ class GaussianPicker(PhasePicker):
             # Add one data point below the threshold at each end of this period
             gau_idxmin = exceedence[tmp][0] + win_min - 1
             gau_idxmax = exceedence[tmp][-1] + win_min + 2
+            logging.debug(f"gau_idxmin = {gau_idxmin} ; "
+                          f"gau_idxmax = {gau_idxmax}")
 
             # Initial guess for gaussian half-width based on onset function
             # STA window length
@@ -360,7 +364,7 @@ class GaussianPicker(PhasePicker):
                 sigma = np.absolute(popt[2])
 
                 # Check pick mean is within the pick window.
-                if not gau_idxmin < popt[1] * self.sampling_rate < gau_idxmax:
+                if not win_min < popt[1] * self.sampling_rate < win_max:
                     gaussian_fit = self.DEFAULT_GAUSSIAN_FIT
                     gaussian_fit["PickThreshold"] = threshold
                     sigma = -1


### PR DESCRIPTION
A check had already been added to ensure the time of the pick was within the picking
window, but it used the incorrect index to make this check. It was based on the
duration of the onset function used for the gaussian fit, so in cases where the onset
function was above the exceedence value at the edge of the pick window, the 1 sample
padding used would give 1 sample of leeway to this check.

This has been corrected so the indices of the pick window itself are used in the test.

A couple of relevant debug messages have also been added.