### PR TITLE
fix(trigger): Fix bug where no events are triggered

### DIFF
--- a/quakemigrate/signal/trigger.py
+++ b/quakemigrate/signal/trigger.py
@@ -280,6 +280,7 @@ class Trigger:
             logging.info("\tNo events triggered at this threshold - try a "
                          "lower detection threshold.")
             events = candidate_events
+            discarded = candidate_events
         else:
             refined_events = self._refine_candidates(candidate_events)
             events = self._filter_events(refined_events, batchstart, batchend,


### PR DESCRIPTION
Previously `discarded` was not assigned in the case that no events were
triggered, leading to an UnboundLocalError - see #125

This is now assigned as the same (empty) DataFrame as `events`.


<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Clearly and concisely describe the problem and how you have resolved it.

### Relevant Issues
Link any open Issues here.

## Test cases
Please detail any tests that you have used to ensure your changes do not introduce bugs.

- [ ] All examples run without any new warnings
- [ ] test_benchmarks.py reports all example tests pass

### System details
Please state the systems on which you have tested this change.

### Final checklist
- [ ] `develop` base branch selected?
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered by new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGES.md`.
- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.
