### PR TITLE
add pandas>1.0, numpy>1.20  compatibility - add pykonal 1dfmm support

### DIFF
--- a/quakemigrate/lut/lut.py
+++ b/quakemigrate/lut/lut.py
@@ -124,7 +124,7 @@ class Grid3D:
 
         """
 
-        df = np.array(df, dtype=np.int)
+        df = np.array(df, dtype=int)
 
         new_node_count = 1 + (self.node_count - 1) // df
         c1 = (self.node_count - df * (new_node_count - 1) - 1) // 2

--- a/quakemigrate/plot/trigger.py
+++ b/quakemigrate/plot/trigger.py
@@ -263,9 +263,9 @@ def _plot_station_availability(ax, availability, endtime):
 
     # Plot formatting
     _add_plot_tag(ax, "Station availability")
-    ax.set_ylim([int(min(min_ava)*0.8), np.int(np.ceil(max(max_ava)*1.1))])
+    ax.set_ylim([int(min(min_ava)*0.8), int(np.ceil(max(max_ava)*1.1))])
     ax.set_yticks(range(int(min(min_ava)*0.8),
-                        np.int(np.ceil(max(max_ava)*1.1))+1))
+                        int(np.ceil(max(max_ava)*1.1))+1))
     ax.xaxis.set_major_formatter(util.DateFormatter("%H:%M:%S.{ms}", 2))
     ax.set_xlabel("DateTime", fontsize=14)
     ax.set_ylabel("Available stations", fontsize=14)

--- a/quakemigrate/signal/onsets/stalta.py
+++ b/quakemigrate/signal/onsets/stalta.py
@@ -47,7 +47,7 @@ def sta_lta_centred(signal, nsta, nlta):
 
     # Cumulative sum to calculate moving average
     sta = np.cumsum(signal ** 2)
-    sta = np.require(sta, dtype=np.float)
+    sta = np.require(sta, dtype=float)
     lta = sta.copy()
 
     # Compute the STA and the LTA

--- a/quakemigrate/signal/scan.py
+++ b/quakemigrate/signal/scan.py
@@ -985,7 +985,7 @@ class QuakeScan:
         x1, y1, z1 = np.clip(i - w2, 0 * n, n)
         x2, y2, z2 = np.clip(i + w2 + 1, 0 * n, n)
 
-        mask = np.zeros(n, dtype=np.bool)
+        mask = np.zeros(n, dtype=bool)
         mask[x1:x2, y1:y2, z1:z2] = True
 
         return mask

--- a/quakemigrate/signal/trigger.py
+++ b/quakemigrate/signal/trigger.py
@@ -405,7 +405,8 @@ class Trigger:
                                  min_dt, max_dt, peak["COA"], peak["COA_N"]],
                                 index=CANDIDATES_COLS)
 
-            triggers = triggers.append(trigger, ignore_index=True)
+            triggers = pd.concat([triggers, pd.DataFrame([trigger])], 
+                                ignore_index=True)
 
         return triggers
 
@@ -468,7 +469,8 @@ class Trigger:
             event_uid = event_uid[:17].ljust(17, "0")
             event["EventID"] = event_uid
 
-            refined_events = refined_events.append(event, ignore_index=True)
+            # refined_events = refined_events.append(event, ignore_index=True)
+            refined_events = pd.concat([refined_events, pd.DataFrame([event])], ignore_index=True)
 
         return refined_events
 

--- a/quakemigrate/util.py
+++ b/quakemigrate/util.py
@@ -553,7 +553,7 @@ def upsample(trace, upfactor, starttime, endtime):
             * trace.stats.sampling_rate * upfactor)
         logging.debug(f"Start pad = {start_pad}")
         # Add padding data (constant value)
-        start_fill = np.full(np.int(start_pad), trace.data[0], dtype=int)
+        start_fill = np.full(int(start_pad), trace.data[0], dtype=int)
         dnew = np.append(start_fill, dnew)
         # Calculate new starttime of trace
         new_starttime = trace.stats.starttime - start_pad \
@@ -570,7 +570,7 @@ def upsample(trace, upfactor, starttime, endtime):
             * trace.stats.sampling_rate * upfactor)
         logging.debug(f"End pad = {end_pad}")
         # Add padding data (constant value)
-        end_fill = np.full(np.int(end_pad), trace.data[-1], dtype=int)
+        end_fill = np.full(int(end_pad), trace.data[-1], dtype=int)
         dnew = np.append(dnew, end_fill)
 
     out = Trace()


### PR DESCRIPTION
    change sections of trigger and locate to be compatible with pandas 1.5
    remove references to np.float, np.int and np.bool and replaced with float, int and bool respectively. This was depreciated in numpy versions > 1.20 and produces errors
    added a new travel time calculation method "1dpykonal". This uses the package pykonal to caulate a 2D grid which is swept across the 3D volume.
    it adds a new dependency (pykonal, cython and hdf5).
    results using the new LUT method are the same as 1dnlloc


<!--
Thank your for contributing to QuakeMigrate!
Please fill out the sections below.
-->

## What is the purpose of this Pull Request? 
Clearly and concisely describe the problem and how you have resolved it.

### Relevant Issues
Link any open Issues here.

## Test cases
Please detail any tests that you have used to ensure your changes do not introduce bugs.

- [ ] All examples run without any new warnings
- [ ] test_benchmarks.py reports all example tests pass

### System details
Please state the systems on which you have tested this change.

### Final checklist
- [ ] `develop` base branch selected?
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are covered by new tests.
- [ ] Any new or changed features are fully documented.
- [ ] Significant changes have been added to `CHANGES.md`.
- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.
